### PR TITLE
Add a prefix like "s3:"

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "semi": [
       "error",
       "always"
-    ]
+    ],
+    "no-console": "off"
   }
 }

--- a/src/actions-getter.js
+++ b/src/actions-getter.js
@@ -14,12 +14,12 @@ const getActions = async (sourceDefinition) => {
     const escapedRegExpString = escapeStringRegexp(prefix);
 
     const name = (() => {
-      const actionName = $element.attr("id").replace(new RegExp(`^${escapedRegExpString}`), "");
+      const actionName = $element.attr("id").replace(new RegExp(`^${escapedRegExpString}`), "").trim();
       if (actionName.length === 0) return;
       const isCamelCase = actionName[0] === actionName[0].toUpperCase();
       if (!isCamelCase) return;
 
-      return actionName.trim() || undefined;
+      return `${sourceDefinition.actionNamePrefix}:${actionName}`;
     })();
     if (name == undefined) return;
 

--- a/src/source-definitions/s3.json
+++ b/src/source-definitions/s3.json
@@ -1,4 +1,5 @@
 {
   "url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html",
-  "anchorElementIdPrefix": "amazons3-"
+  "anchorElementIdPrefix": "amazons3-",
+  "actionNamePrefix": "s3"
 }


### PR DESCRIPTION
# New Features
- Add a prefix like "s3:"


# Changes and Fixes
- Allow `console.log` for ESLint
