### PR TITLE
Change command name

### DIFF
--- a/bin/aws-actions-list
+++ b/bin/aws-actions-list
@@ -16,4 +16,8 @@ commander
   .description("show and output specified AWS actions list")
   .action(program.executeInteractively);
 
+commander
+  .command("*")
+  .action((input) => console.error(`unknown command: ${input}`));
+
 commander.parse(process.argv);

--- a/bin/aws-actions-list
+++ b/bin/aws-actions-list
@@ -12,8 +12,8 @@ if (process.argv.length === 2) process.argv.push('--help')
 commander.version(version, "-v, --version");
 
 commander
-  .command("get")
-  .description("get and output specified AWS actions")
+  .command("show")
+  .description("show and output specified AWS actions list")
   .action(program.executeInteractively);
 
 commander.parse(process.argv);


### PR DESCRIPTION
# New Features
- Show error message when a command does not exist


# Changes and Fixes
- Rename `get` command to `show`
